### PR TITLE
fix: add warning for mixed casing in FROM and AS keywords

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7 as builder
+FROM centos:centos7 AS builder
 WORKDIR /tmp
 COPY .  .
 
@@ -32,7 +32,7 @@ RUN ./configure \
 
 RUN /opt/jxwaf/nginx/sbin/nginx -t
 
-FROM golang:1.19 as go_builder
+FROM golang:1.19 AS go_builder
 WORKDIR /opt/app
 
 COPY ./tools/dockerun /opt/app


### PR DESCRIPTION
This PR adds a warning for the `FromAsCasing` rule, addressing the issue of inconsistent casing between the `FROM` and `AS` keywords in Dockerfiles. The rule enforces consistent casing for readability and maintainability, providing a warning message when mixed casing occurs.

### Changes:

- Added a warning message:  
  `WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match`

### Examples:

❌ **Bad:** `FROM` is uppercase, `AS` is lowercase.   `FROM debian:latest as builder`

✅ Good: FROM and AS are both uppercase.
`FROM debian:latest AS deb-builder`

✅ Good: FROM and AS are both lowercase.
`from debian:latest as deb-builder`

For more information, refer to the Dockerfile checks documentation: [Dockerfile FROM-AS Casing](https://docs.docker.com/reference/build-checks/from-as-casing/